### PR TITLE
Fix#4 - datetime length

### DIFF
--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -133,6 +133,24 @@ class Snowflake extends Common
                     break;
                 }
                 break;
+            case "TIME":
+            case "DATETIME":
+            case "TIMESTAMP":
+            case "TIMESTAMP_NTZ":
+            case "TIMESTAMP_LTZ":
+            case "TIMESTAMP_TZ":
+                if (is_null($length) || $length == "") {
+                    break;
+                }
+                if (!is_numeric($length)) {
+                    $valid = false;
+                    break;
+                }
+                if ((int)$length < 0 || (int)$length > 9) {
+                    $valid = false;
+                    break;
+                }
+                break;
             default:
                 if (!is_null($length) && $length != "") {
                     $valid = false;

--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -47,7 +47,7 @@ class Snowflake extends Common
     public function getSQLDefinition()
     {
         $definition =  $this->getType();
-        if ($this->getLength() && $this->getLength() != "") {
+        if ($this->getLength() !== null && $this->getLength() != "") {
             $definition .= "(" . $this->getLength() . ")";
         }
         if (!$this->isNullable()) {

--- a/tests/SnowflakeDatatypeTest.php
+++ b/tests/SnowflakeDatatypeTest.php
@@ -57,6 +57,7 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
         new Snowflake("TIMESTAMP_LTZ", ["length" => "4"]);
         new Snowflake("TIMESTAMP_TZ", ["length" => "0"]);
         new Snowflake("TIMESTAMP_NTZ", ["length" => "9"]);
+        new Snowflake("TIME", ["length" => "9"]);
     }
 
     public function testSqlDefinition()

--- a/tests/SnowflakeDatatypeTest.php
+++ b/tests/SnowflakeDatatypeTest.php
@@ -48,6 +48,31 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testValidDateTimeLengths()
+    {
+        new Snowflake("datetime");
+        new Snowflake("DATETIME");
+        new Snowflake("DATETIME", ["length" => ""]);
+        new Snowflake("TIMESTAMP", ["length" => ""]);
+        new Snowflake("TIMESTAMP_LTZ", ["length" => "4"]);
+        new Snowflake("TIMESTAMP_TZ", ["length" => "0"]);
+        new Snowflake("TIMESTAMP_NTZ", ["length" => "9"]);
+    }
+
+    /**
+     * @dataProvider invalidDateTimeLengths
+     * @param $length
+     */
+    public function testInvalidDateTimeLengths($length)
+    {
+        try {
+            new Snowflake("DATETIME", ["length" => $length]);
+            $this->fail("Exception not caught");
+        } catch (\Exception $e) {
+            $this->assertEquals(InvalidLengthException::class, get_class($e));
+        }
+    }
+
     public function testInvalidOption()
     {
         try {
@@ -148,6 +173,18 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
             ["0"],
             ["16777217"],
             ["-1"]
+        ];
+    }
+
+    public function invalidDateTimeLengths()
+    {
+        return [
+            ["notANumber"],
+            ["0,0"],
+            ["-1"],
+            ["10"],
+            ["a"],
+            ["a,a"]
         ];
     }
 }

--- a/tests/SnowflakeDatatypeTest.php
+++ b/tests/SnowflakeDatatypeTest.php
@@ -59,6 +59,24 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
         new Snowflake("TIMESTAMP_NTZ", ["length" => "9"]);
     }
 
+    public function testSqlDefinition()
+    {
+        $definition = new Snowflake("NUMERIC", ["length" => ""]);
+        $this->assertTrue($definition->getSQLDefinition() === "NUMERIC");
+
+        $definition = new Snowflake("TIMESTAMP_TZ", ["length" => "0"]);
+        $this->assertTrue($definition->getSQLDefinition() === "TIMESTAMP_TZ(0)");
+
+        $definition = new Snowflake("TIMESTAMP_TZ", ["length" => "9"]);
+        $this->assertTrue($definition->getSQLDefinition() === "TIMESTAMP_TZ(9)");
+
+        $definition = new Snowflake("TIMESTAMP_TZ", ["length" => ""]);
+        $this->assertTrue($definition->getSQLDefinition() === "TIMESTAMP_TZ");
+
+        $definition = new Snowflake("TIMESTAMP_TZ");
+        $this->assertTrue($definition->getSQLDefinition() === "TIMESTAMP_TZ");
+    }
+
     /**
      * @dataProvider invalidDateTimeLengths
      * @param $length


### PR DESCRIPTION
Fixed Snowflake
- length validation for datetime/timestamp data types
- SQL defition generator for data types with ZERO length (f.e.: TIMESTAMP(0))
https://docs.snowflake.net/manuals/sql-reference/data-types-datetime.html#time