### PR TITLE
Basetype for enum should be string

### DIFF
--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -96,16 +96,21 @@ class GenericStorage extends Common
         if (stristr($this->type, "int")) {
             return "INTEGER";
         }
-        if (stristr($this->type, "float") || stristr($this->type, "double") || stristr($this->type, "real")) {
+        if (stripos($this->type, "float") === 0 || stripos($this->type, "real") === 0) {
             return "FLOAT";
         }
         if (stristr($this->type, "timestamp")) {
             return "TIMESTAMP";
         }
-        if (stristr($this->type, "bool")) {
+        if (stripos($this->type, "bool") === 0) {
             return "BOOLEAN";
         }
-        if (stristr($this->type, "decimal") || stristr($this->type, "num")) {
+        if (
+            stripos($this->type, "decimal") === 0 ||
+            stripos($this->type, "num") === 0 ||
+            stristr($this->type, "double")
+        )
+        {
             return "NUMERIC";
         }
         return "STRING";

--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -92,25 +92,17 @@ class GenericStorage extends Common
                 return "TIMESTAMP";
             }
             return "DATE";
-        }
-        if (stristr($this->type, "int")) {
+        } else if (stristr($this->type, "int")) {
             return "INTEGER";
-        }
-        if (stripos($this->type, "float") === 0 || stripos($this->type, "real") === 0) {
+        } else if (stripos($this->type, "float") === 0 || stripos($this->type, "real") === 0) {
             return "FLOAT";
-        }
-        if (stristr($this->type, "timestamp")) {
+        } else if (stristr($this->type, "timestamp")) {
             return "TIMESTAMP";
-        }
-        if (stripos($this->type, "bool") === 0) {
+        } else if (stripos($this->type, "bool") === 0) {
             return "BOOLEAN";
-        }
-        if (
-            stripos($this->type, "decimal") === 0 ||
+        } else if (stripos($this->type, "decimal") === 0 ||
             stripos($this->type, "num") === 0 ||
-            stristr($this->type, "double")
-        )
-        {
+            stristr($this->type, "double")) {
             return "NUMERIC";
         }
         return "STRING";

--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -110,24 +110,25 @@ class GenericStorage extends Common
     public function getBasetype()
     {
         $type = strtolower($this->type);
+        $baseType = "STRING";
         if (in_array($type, self::DATE_TYPES)) {
-            return "DATE";
+            $baseType = "DATE";
         }
         if (in_array($type, self::TIMESTAMP_TYPES)) {
-            return "TIMESTAMP";
+            $baseType = "TIMESTAMP";
         }
         if (in_array($type, self::INTEGER_TYPES)) {
-            return "INTEGER";
+            $baseType = "INTEGER";
         }
         if (in_array($type, self::FIXED_NUMERIC_TYPES)) {
-            return "NUMERIC";
+            $baseType = "NUMERIC";
         }
         if (in_array($type, self::FLOATING_POINT_TYPES)) {
-            return "FLOAT";
+            $baseType = "FLOAT";
         }
         if (in_array($type, self::BOOLEAN_TYPES)) {
-            return "BOOLEAN";
+            $baseType = "BOOLEAN";
         }
-        return "STRING";
+        return $baseType;
     }
 }

--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -4,6 +4,28 @@ namespace Keboola\Datatype\Definition;
 
 class GenericStorage extends Common
 {
+    const DATE_TYPES = ["date"];
+    const TIMESTAMP_TYPES = [
+        "datetime", "datetime2", "smalldatetime", "datetimeoffset", "timestamp_LTZ", "timestamp_NTZ", "TIMESTAMP_TZ",
+        "timestamptz", "timestamp", "timestamp with timezone", "timestamp with local timezone"
+    ];
+    const FLOATING_POINT_TYPES = [
+        "real", "float", "float4", "double precision", "float8", "binary_float", "binary_double", "double"
+    ];
+    // NOTE: "bit" is used in mssql as a 1/0 type boolean, but in pgsql as a bit(n) ie 10110.
+    // also in mysql bit is equivalent to tinyint
+    const BOOLEAN_TYPES = ["boolean", "bool"];
+
+    const INTEGER_TYPES = [
+        "integer", "int", "smallint", "mediumint",
+        "int2", "tinyint", "bigint", "int8", "bigserial", "serial8", "int4"
+    ];
+
+    const FIXED_NUMERIC_TYPES = [
+        "numeric", "decimal", "dec", "fixed", "money", "smallmoney", "number"
+    ];
+
+
     /**
      * @var string
      */
@@ -87,23 +109,24 @@ class GenericStorage extends Common
      */
     public function getBasetype()
     {
-        if (stristr($this->type, "date")) {
-            if (stristr($this->type, "time")) {
-                return "TIMESTAMP";
-            }
+        $type = strtolower($this->type);
+        if (in_array($type, self::DATE_TYPES)) {
             return "DATE";
-        } else if (stristr($this->type, "int")) {
-            return "INTEGER";
-        } else if (stripos($this->type, "float") === 0 || stripos($this->type, "real") === 0) {
-            return "FLOAT";
-        } else if (stristr($this->type, "timestamp")) {
+        }
+        if (in_array($type, self::TIMESTAMP_TYPES)) {
             return "TIMESTAMP";
-        } else if (stripos($this->type, "bool") === 0) {
-            return "BOOLEAN";
-        } else if (stripos($this->type, "decimal") === 0 ||
-            stripos($this->type, "num") === 0 ||
-            stristr($this->type, "double")) {
+        }
+        if (in_array($type, self::INTEGER_TYPES)) {
+            return "INTEGER";
+        }
+        if (in_array($type, self::FIXED_NUMERIC_TYPES)) {
             return "NUMERIC";
+        }
+        if (in_array($type, self::FLOATING_POINT_TYPES)) {
+            return "FLOAT";
+        }
+        if (in_array($type, self::BOOLEAN_TYPES)) {
+            return "BOOLEAN";
         }
         return "STRING";
     }

--- a/tests/GenericStorageDatatypeTest.php
+++ b/tests/GenericStorageDatatypeTest.php
@@ -14,12 +14,12 @@ class GenericStorageDatatypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("TIMESTAMP", (new GenericStorage("timestamp"))->getBasetype());
         $this->assertEquals("STRING", (new GenericStorage("dattim"))->getBasetype());
 
-        $this->assertEquals("INTEGER", (new GenericStorage("int16"))->getBasetype());
+        $this->assertEquals("INTEGER", (new GenericStorage("int8"))->getBasetype());
         $this->assertEquals("INTEGER", (new GenericStorage("int"))->getBasetype());
         $this->assertEquals("INTEGER", (new GenericStorage("INTEGER"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("float8"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("REAL"))->getBasetype());
-        $this->assertEquals("NUMERIC", (new GenericStorage("double precision"))->getBasetype());
+        $this->assertEquals("FLOAT", (new GenericStorage("double precision"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("number"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("DECIMAL"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("numeric"))->getBasetype());

--- a/tests/GenericStorageDatatypeTest.php
+++ b/tests/GenericStorageDatatypeTest.php
@@ -19,7 +19,7 @@ class GenericStorageDatatypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("INTEGER", (new GenericStorage("INTEGER"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("float8"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("REAL"))->getBasetype());
-        $this->assertEquals("NUMERIC", (new GenericStorage("double percision"))->getBasetype());
+        $this->assertEquals("NUMERIC", (new GenericStorage("double precision"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("number"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("DECIMAL"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("numeric"))->getBasetype());

--- a/tests/GenericStorageDatatypeTest.php
+++ b/tests/GenericStorageDatatypeTest.php
@@ -19,7 +19,7 @@ class GenericStorageDatatypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("INTEGER", (new GenericStorage("INTEGER"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("float8"))->getBasetype());
         $this->assertEquals("FLOAT", (new GenericStorage("REAL"))->getBasetype());
-        $this->assertEquals("FLOAT", (new GenericStorage("double percision"))->getBasetype());
+        $this->assertEquals("NUMERIC", (new GenericStorage("double percision"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("number"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("DECIMAL"))->getBasetype());
         $this->assertEquals("NUMERIC", (new GenericStorage("numeric"))->getBasetype());

--- a/tests/GenericStorageDatatypeTest.php
+++ b/tests/GenericStorageDatatypeTest.php
@@ -27,6 +27,8 @@ class GenericStorageDatatypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("BOOLEAN", (new GenericStorage("BOOL"))->getBasetype());
         $this->assertEquals("BOOLEAN", (new GenericStorage("boolean"))->getBasetype());
 
+        $this->assertEquals("STRING", (new GenericStorage("enum"))->getBasetype());
+
         $this->assertEquals("STRING", (new GenericStorage("anythingelse"))->getBasetype());
     }
 


### PR DESCRIPTION
Also, all unexpected types should have `string` as basetype.

fixes #9 