### PR TITLE
feat: binary datatype for Snowflake

### DIFF
--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -21,7 +21,8 @@ class Snowflake extends Common
         "DATETIME",
         "TIME",
         "TIMESTAMP", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP_TZ",
-        "VARIANT"
+        "VARIANT",
+        "BINARY","VARBINARY",
     ];
 
     /**
@@ -148,6 +149,20 @@ class Snowflake extends Common
                     break;
                 }
                 if ((int)$length < 0 || (int)$length > 9) {
+                    $valid = false;
+                    break;
+                }
+                break;
+            case "BINARY":
+            case "VARBINARY":
+                if (is_null($length) || $length == "") {
+                    break;
+                }
+                if (!is_numeric($length)) {
+                    $valid = false;
+                    break;
+                }
+                if ((int)$length < 1 || (int)$length > 8388608) {
                     $valid = false;
                     break;
                 }

--- a/tests/SnowflakeDatatypeTest.php
+++ b/tests/SnowflakeDatatypeTest.php
@@ -60,6 +60,19 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
         new Snowflake("TIME", ["length" => "9"]);
     }
 
+    public function testValidBinaryLengths()
+    {
+        new Snowflake("binary");
+        new Snowflake("varbinary");
+        new Snowflake("VARBINARY");
+        new Snowflake("BINARY", ["length" => ""]);
+        new Snowflake("VARBINARY", ["length" => ""]);
+        new Snowflake("BINARY", ["length" => "1"]);
+        new Snowflake("VARBINARY", ["length" => "1"]);
+        new Snowflake("BINARY", ["length" => "8388608"]);
+        new Snowflake("VARBINARY", ["length" => "8388608"]);
+    }
+
     public function testSqlDefinition()
     {
         $definition = new Snowflake("NUMERIC", ["length" => ""]);
@@ -119,6 +132,27 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
     {
         try {
             new Snowflake("STRING", ["length" => $length]);
+            $this->fail("Exception not caught");
+        } catch (\Exception $e) {
+            $this->assertEquals(InvalidLengthException::class, get_class($e));
+        }
+    }
+
+    /**
+     * @dataProvider invalidBinaryLengths
+     * @param $length
+     */
+    public function testInvalidBinaryLengths($length)
+    {
+        try {
+            new Snowflake("BINARY", ["length" => $length]);
+            $this->fail("Exception not caught");
+        } catch (\Exception $e) {
+            $this->assertEquals(InvalidLengthException::class, get_class($e));
+        }
+
+        try {
+            new Snowflake("VARBINARY", ["length" => $length]);
             $this->fail("Exception not caught");
         } catch (\Exception $e) {
             $this->assertEquals(InvalidLengthException::class, get_class($e));
@@ -209,6 +243,16 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
             ["10"],
             ["a"],
             ["a,a"]
+        ];
+    }
+
+    public function invalidBinaryLengths()
+    {
+        return [
+            ["a"],
+            ["0"],
+            ["8388609"],
+            ["-1"]
         ];
     }
 }


### PR DESCRIPTION
Podpora pro datove typy `BINARY` a `VARBINARY`
https://docs.snowflake.net/manuals/sql-reference/data-types-text.html#data-types-for-binary-strings

Potrebuju to kvuli Snowflake writeru a nevidim duvod tady nemit pro to podporu. Pro MySQL taky podporujeme `BLOB`