### PR TITLE
Redshift skip length validation option

### DIFF
--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -26,13 +26,15 @@ class Redshift extends Common
      * Redshift constructor.
      *
      * @param string $type
-     * @param array $options -- length, nullable, default, compression
+     * @param array $options -- length, nullable, default, compression, skipLengthValidation
      * @throws InvalidOptionException
      */
     public function __construct($type, $options = [])
     {
         $this->validateType($type);
-        $this->validateLength($type, isset($options["length"]) ? $options["length"] : null);
+        if (!$options['skipLengthValidation']) {
+            $this->validateLength($type, isset($options["length"]) ? $options["length"] : null);
+        }
         if (isset($options['compression'])) {
             $this->validateCompression($type, $options['compression']);
             $this->compression = $options['compression'];

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -308,8 +308,7 @@ class Redshift extends Common
     {
         if (in_array($this->getBasetype(), ["STRING", "NUMERIC"])) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 }

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -26,15 +26,14 @@ class Redshift extends Common
      * Redshift constructor.
      *
      * @param string $type
-     * @param array $options -- length, nullable, default, compression, skipLengthValidation
+     * @param array $options -- length, nullable, default, compression
      * @throws InvalidOptionException
      */
     public function __construct($type, $options = [])
     {
         $this->validateType($type);
-        if (!$options['skipLengthValidation']) {
-            $this->validateLength($type, isset($options["length"]) ? $options["length"] : null);
-        }
+        $this->validateLength($type, isset($options["length"]) ? $options["length"] : null);
+
         if (isset($options['compression'])) {
             $this->validateCompression($type, $options['compression']);
             $this->compression = $options['compression'];

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -303,12 +303,4 @@ class Redshift extends Common
         }
         return $metadata;
     }
-
-    public function supportsLength()
-    {
-        if (in_array($this->getBasetype(), ["STRING", "NUMERIC"])) {
-            return true;
-        }
-        return false;
-    }
 }

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -164,7 +164,22 @@ class Redshift extends Common
                     break;
                 }
                 break;
-
+            case "TIMESTAMP":
+            case "TIMESTAMP WITHOUT TIME ZONE":
+            case "TIMESTAMPTZ":
+            case "TIMESTAMP WITH TIME ZONE":
+                if (is_null($length) || $length == "") {
+                    break;
+                }
+                if (!is_numeric($length)) {
+                    $valid = false;
+                    break;
+                }
+                if ((int)$length <= 0 || (int)$length > 11) {
+                    $valid = false;
+                    break;
+                }
+                break;
             default:
                 if (!is_null($length) && $length != "") {
                     $valid = false;

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -303,4 +303,13 @@ class Redshift extends Common
         }
         return $metadata;
     }
+
+    public function supportsLength(): bool
+    {
+        if (in_array($this->getBasetype(), ["STRING", "NUMERIC"])) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -304,7 +304,7 @@ class Redshift extends Common
         return $metadata;
     }
 
-    public function supportsLength(): bool
+    public function supportsLength()
     {
         if (in_array($this->getBasetype(), ["STRING", "NUMERIC"])) {
             return true;

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -234,13 +234,13 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
      * @param $type
      * @param $expectedSupport
      */
-    public function testSupportsLength(string $type, bool $expectedSupport)
+    public function testSupportsLength($type, $expectedSupport)
     {
         $redshiftType = new Redshift($type);
         $this->assertEquals($expectedSupport, $redshiftType->supportsLength());
     }
 
-    public function lengthSupportedProvider(): array
+    public function lengthSupportedProvider()
     {
         return [
             ["NVARCHAR", true],

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -229,27 +229,6 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @dataProvider lengthSupportedProvider
-     * @param $type
-     * @param $expectedSupport
-     */
-    public function testSupportsLength($type, $expectedSupport)
-    {
-        $redshiftType = new Redshift($type);
-        $this->assertEquals($expectedSupport, $redshiftType->supportsLength());
-    }
-
-    public function lengthSupportedProvider()
-    {
-        return [
-            ["NVARCHAR", true],
-            ["DECIMAL", true],
-            ["DATE", false],
-            ["TIMESTAMP", false],
-        ];
-    }
-
     public function invalidNumericLengths()
     {
         return [

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -229,6 +229,11 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testSkipLengthValidation()
+    {
+        new Redshift("timestamp", ["length" => "8", "skipLengthValidation" => true]);
+    }
+
     public function invalidNumericLengths()
     {
         return [

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -72,6 +72,22 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @dataProvider timestampLengths
+     * @param $type
+     * @param $length
+     * @param $expectedValid
+     */
+    public function testTimestampLengths($type, $length, $expectedValid)
+    {
+        if (!$expectedValid) {
+            $this->expectException(InvalidLengthException::class);
+            new Redshift($type, ["length" => $length]);
+        } else {
+            new Redshift($type, ["length" => $length]);
+        }
+    }
+
     public function testValidCharLengths()
     {
         new Redshift("char");
@@ -274,6 +290,82 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
             ["VARCHAR", "MOSTLY32"],
             ["NUMERIC", "TEXT255"],
             ["NUMERIC","TEXT32K"]
+        ];
+    }
+
+    public function timestampLengths()
+    {
+        return [
+            [
+                "timestamp",
+                "-1",
+                false
+            ],
+            [
+                "timestamp",
+                "15",
+                false
+            ],
+            [
+                "timestamp",
+                "abc",
+                false
+            ],
+            [
+                "timestamp",
+                "8,3",
+                false
+            ],
+            [
+                "timestamp",
+                null,
+                true
+            ],
+            [
+                "timestamp",
+                "",
+                true
+            ],
+            [
+                "timestamp",
+                "8",
+                true
+            ],
+            [
+                "timestamptz",
+                "-1",
+                false
+            ],
+            [
+                "timestamptz",
+                "15",
+                false
+            ],
+            [
+                "timestamptz",
+                "abc",
+                false
+            ],
+            [
+                "timestamptz",
+                "8,3",
+                false
+            ],
+            [
+                "timestamptz",
+                null,
+                true
+            ],
+            [
+                "timestamptz",
+                "",
+                true
+            ],
+            [
+                "timestamptz",
+                "8",
+                true
+            ],
         ];
     }
 }

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -229,9 +229,25 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testSkipLengthValidation()
+    /**
+     * @dataProvider lengthSupportedProvider
+     * @param $type
+     * @param $expectedSupport
+     */
+    public function testSupportsLength(string $type, bool $expectedSupport)
     {
-        new Redshift("timestamp", ["length" => "8", "skipLengthValidation" => true]);
+        $redshiftType = new Redshift($type);
+        $this->assertEquals($expectedSupport, $redshiftType->supportsLength());
+    }
+
+    public function lengthSupportedProvider(): array
+    {
+        return [
+            ["NVARCHAR", true],
+            ["DECIMAL", true],
+            ["DATE", false],
+            ["TIMESTAMP", false],
+        ];
     }
 
     public function invalidNumericLengths()


### PR DESCRIPTION
the describe table method gives lengths for timestamps, and I think that's fine so it should be able to skip this validation if wanted.  