### PR TITLE
Convert base types to constants

### DIFF
--- a/src/Definition/BaseType.php
+++ b/src/Definition/BaseType.php
@@ -4,11 +4,11 @@ namespace Keboola\Datatype\Definition;
 
 class BaseType
 {
-    public const BOOLEAN = "BOOLEAN";
-    public const DATE = "DATE";
-    public const FLOAT = "FLOAT";
-    public const INTEGER = "INTEGER";
-    public const NUMERIC = "NUMERIC";
-    public const STRING = "STRING";
-    public const TIMESTAMP = "TIMESTAMP";
+    const BOOLEAN = "BOOLEAN";
+    const DATE = "DATE";
+    const FLOAT = "FLOAT";
+    const INTEGER = "INTEGER";
+    const NUMERIC = "NUMERIC";
+    const STRING = "STRING";
+    const TIMESTAMP = "TIMESTAMP";
 }

--- a/src/Definition/BaseType.php
+++ b/src/Definition/BaseType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Keboola\Datatype\Definition;
+
+class BaseType
+{
+    public const BOOLEAN = "BOOLEAN";
+    public const DATE = "DATE";
+    public const FLOAT = "FLOAT";
+    public const INTEGER = "INTEGER";
+    public const NUMERIC = "NUMERIC";
+    public const STRING = "STRING";
+    public const TIMESTAMP = "TIMESTAMP";
+}

--- a/src/Definition/Common.php
+++ b/src/Definition/Common.php
@@ -4,6 +4,14 @@ namespace Keboola\Datatype\Definition;
 
 abstract class Common
 {
+    const BASE_TYPE_BOOLEAN = "BOOLEAN";
+    const BASE_TYPE_DATE = "DATE";
+    const BASE_TYPE_FLOAT = "FLOAT";
+    const BASE_TYPE_INTEGER = "INTEGER";
+    const BASE_TYPE_NUMERIC = "NUMERIC";
+    const BASE_TYPE_STRING = "STRING";
+    const BASE_TYPE_TIMESTAMP = "TIMESTAMP";
+
     /**
      * @var string
      */

--- a/src/Definition/Common.php
+++ b/src/Definition/Common.php
@@ -4,13 +4,6 @@ namespace Keboola\Datatype\Definition;
 
 abstract class Common
 {
-    const BASE_TYPE_BOOLEAN = "BOOLEAN";
-    const BASE_TYPE_DATE = "DATE";
-    const BASE_TYPE_FLOAT = "FLOAT";
-    const BASE_TYPE_INTEGER = "INTEGER";
-    const BASE_TYPE_NUMERIC = "NUMERIC";
-    const BASE_TYPE_STRING = "STRING";
-    const BASE_TYPE_TIMESTAMP = "TIMESTAMP";
 
     /**
      * @var string

--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -25,7 +25,6 @@ class GenericStorage extends Common
         "numeric", "decimal", "dec", "fixed", "money", "smallmoney", "number"
     ];
 
-
     /**
      * @var string
      */
@@ -110,24 +109,24 @@ class GenericStorage extends Common
     public function getBasetype()
     {
         $type = strtolower($this->type);
-        $baseType = "STRING";
+        $baseType = Common::BASE_TYPE_STRING;
         if (in_array($type, self::DATE_TYPES)) {
-            $baseType = "DATE";
+            $baseType = Common::BASE_TYPE_DATE;
         }
         if (in_array($type, self::TIMESTAMP_TYPES)) {
-            $baseType = "TIMESTAMP";
+            $baseType = Common::BASE_TYPE_TIMESTAMP;
         }
         if (in_array($type, self::INTEGER_TYPES)) {
-            $baseType = "INTEGER";
+            $baseType = Common::BASE_TYPE_INTEGER;
         }
         if (in_array($type, self::FIXED_NUMERIC_TYPES)) {
-            $baseType = "NUMERIC";
+            $baseType = Common::BASE_TYPE_NUMERIC;
         }
         if (in_array($type, self::FLOATING_POINT_TYPES)) {
-            $baseType = "FLOAT";
+            $baseType = Common::BASE_TYPE_FLOAT;
         }
         if (in_array($type, self::BOOLEAN_TYPES)) {
-            $baseType = "BOOLEAN";
+            $baseType = Common::BASE_TYPE_BOOLEAN;
         }
         return $baseType;
     }

--- a/src/Definition/GenericStorage.php
+++ b/src/Definition/GenericStorage.php
@@ -109,24 +109,24 @@ class GenericStorage extends Common
     public function getBasetype()
     {
         $type = strtolower($this->type);
-        $baseType = Common::BASE_TYPE_STRING;
+        $baseType = BaseType::STRING;
         if (in_array($type, self::DATE_TYPES)) {
-            $baseType = Common::BASE_TYPE_DATE;
+            $baseType = BaseType::DATE;
         }
         if (in_array($type, self::TIMESTAMP_TYPES)) {
-            $baseType = Common::BASE_TYPE_TIMESTAMP;
+            $baseType = BaseType::TIMESTAMP;
         }
         if (in_array($type, self::INTEGER_TYPES)) {
-            $baseType = Common::BASE_TYPE_INTEGER;
+            $baseType = BaseType::INTEGER;
         }
         if (in_array($type, self::FIXED_NUMERIC_TYPES)) {
-            $baseType = Common::BASE_TYPE_NUMERIC;
+            $baseType = BaseType::NUMERIC;
         }
         if (in_array($type, self::FLOATING_POINT_TYPES)) {
-            $baseType = Common::BASE_TYPE_FLOAT;
+            $baseType = BaseType::FLOAT;
         }
         if (in_array($type, self::BOOLEAN_TYPES)) {
-            $baseType = Common::BASE_TYPE_BOOLEAN;
+            $baseType = BaseType::BOOLEAN;
         }
         return $baseType;
     }

--- a/src/Definition/MySQL.php
+++ b/src/Definition/MySQL.php
@@ -231,29 +231,29 @@ class MySQL extends Common
             case "SMALLINT":
             case "TINYINT":
             case "MEDIUMINT":
-                $basetype = "INTEGER";
+                $basetype = Common::BASE_TYPE_INTEGER;
                 break;
             case "NUMERIC":
             case "DECIMAL":
             case "DEC":
             case "FIXED":
-                $basetype = "NUMERIC";
+                $basetype = Common::BASE_TYPE_NUMERIC;
                 break;
             case "FLOAT":
             case "DOUBLE PRECISION":
             case "REAL":
             case "DOUBLE":
-                $basetype = "FLOAT";
+                $basetype = Common::BASE_TYPE_FLOAT;
                 break;
             case "DATE":
-                $basetype = "DATE";
+                $basetype = Common::BASE_TYPE_DATE;
                 break;
             case "DATETIME":
             case "TIMESTAMP":
-                $basetype = "TIMESTAMP";
+                $basetype = Common::BASE_TYPE_TIMESTAMP;
                 break;
             default:
-                $basetype = "STRING";
+                $basetype = Common::BASE_TYPE_STRING;
                 break;
         }
         return $basetype;

--- a/src/Definition/MySQL.php
+++ b/src/Definition/MySQL.php
@@ -231,29 +231,29 @@ class MySQL extends Common
             case "SMALLINT":
             case "TINYINT":
             case "MEDIUMINT":
-                $basetype = Common::BASE_TYPE_INTEGER;
+                $basetype = BaseType::INTEGER;
                 break;
             case "NUMERIC":
             case "DECIMAL":
             case "DEC":
             case "FIXED":
-                $basetype = Common::BASE_TYPE_NUMERIC;
+                $basetype = BaseType::NUMERIC;
                 break;
             case "FLOAT":
             case "DOUBLE PRECISION":
             case "REAL":
             case "DOUBLE":
-                $basetype = Common::BASE_TYPE_FLOAT;
+                $basetype = BaseType::FLOAT;
                 break;
             case "DATE":
-                $basetype = Common::BASE_TYPE_DATE;
+                $basetype = BaseType::DATE;
                 break;
             case "DATETIME":
             case "TIMESTAMP":
-                $basetype = Common::BASE_TYPE_TIMESTAMP;
+                $basetype = BaseType::TIMESTAMP;
                 break;
             default:
-                $basetype = Common::BASE_TYPE_STRING;
+                $basetype = BaseType::STRING;
                 break;
         }
         return $basetype;

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -271,34 +271,34 @@ class Redshift extends Common
             case "INT4":
             case "BIGINT":
             case "INT8":
-                $basetype = Common::BASE_TYPE_INTEGER;
+                $basetype = BaseType::INTEGER;
                 break;
             case "DECIMAL":
             case "NUMERIC":
-                $basetype = Common::BASE_TYPE_NUMERIC;
+                $basetype = BaseType::NUMERIC;
                 break;
             case "REAL":
             case "FLOAT4":
             case "DOUBLE PRECISION":
             case "FLOAT8":
             case "FLOAT":
-                $basetype = Common::BASE_TYPE_FLOAT;
+                $basetype = BaseType::FLOAT;
                 break;
             case "BOOLEAN":
             case "BOOL":
-                $basetype =Common::BASE_TYPE_BOOLEAN;
+                $basetype = BaseType::BOOLEAN;
                 break;
             case "DATE":
-                $basetype = Common::BASE_TYPE_DATE;
+                $basetype = BaseType::DATE;
                 break;
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
             case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                $basetype = Common::BASE_TYPE_TIMESTAMP;
+                $basetype = BaseType::TIMESTAMP;
                 break;
             default:
-                $basetype = Common::BASE_TYPE_STRING;
+                $basetype = BaseType::STRING;
                 break;
         }
         return $basetype;

--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -271,34 +271,34 @@ class Redshift extends Common
             case "INT4":
             case "BIGINT":
             case "INT8":
-                $basetype = "INTEGER";
+                $basetype = Common::BASE_TYPE_INTEGER;
                 break;
             case "DECIMAL":
             case "NUMERIC":
-                $basetype = "NUMERIC";
+                $basetype = Common::BASE_TYPE_NUMERIC;
                 break;
             case "REAL":
             case "FLOAT4":
             case "DOUBLE PRECISION":
             case "FLOAT8":
             case "FLOAT":
-                $basetype = "FLOAT";
+                $basetype = Common::BASE_TYPE_FLOAT;
                 break;
             case "BOOLEAN":
             case "BOOL":
-                $basetype ="BOOLEAN";
+                $basetype =Common::BASE_TYPE_BOOLEAN;
                 break;
             case "DATE":
-                $basetype = "DATE";
+                $basetype = Common::BASE_TYPE_DATE;
                 break;
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
             case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                $basetype = "TIMESTAMP";
+                $basetype = Common::BASE_TYPE_TIMESTAMP;
                 break;
             default:
-                $basetype = "STRING";
+                $basetype = Common::BASE_TYPE_STRING;
                 break;
         }
         return $basetype;

--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -191,12 +191,12 @@ class Snowflake extends Common
             case "SMALLINT":
             case "TINYINT":
             case "BYTEINT":
-                $basetype = "INTEGER";
+                $basetype = Common::BASE_TYPE_INTEGER;
                 break;
             case "NUMBER":
             case "DECIMAL":
             case "NUMERIC":
-                $basetype = "NUMERIC";
+                $basetype = Common::BASE_TYPE_NUMERIC;
                 break;
             case "FLOAT":
             case "FLOAT4":
@@ -204,23 +204,23 @@ class Snowflake extends Common
             case "DOUBLE":
             case "DOUBLE PRECISION":
             case "REAL":
-                $basetype = "FLOAT";
+                $basetype = Common::BASE_TYPE_FLOAT;
                 break;
             case "BOOLEAN":
-                $basetype = "BOOLEAN";
+                $basetype = Common::BASE_TYPE_BOOLEAN;
                 break;
             case "DATE":
-                $basetype = "DATE";
+                $basetype = Common::BASE_TYPE_DATE;
                 break;
             case "DATETIME":
             case "TIMESTAMP":
             case "TIMESTAMP_NTZ":
             case "TIMESTAMP_LTZ":
             case "TIMESTAMP_TZ":
-                $basetype = "TIMESTAMP";
+                $basetype = Common::BASE_TYPE_TIMESTAMP;
                 break;
             default:
-                $basetype = "STRING";
+                $basetype = Common::BASE_TYPE_STRING;
                 break;
         }
         return $basetype;

--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -191,12 +191,12 @@ class Snowflake extends Common
             case "SMALLINT":
             case "TINYINT":
             case "BYTEINT":
-                $basetype = Common::BASE_TYPE_INTEGER;
+                $basetype = BaseType::INTEGER;
                 break;
             case "NUMBER":
             case "DECIMAL":
             case "NUMERIC":
-                $basetype = Common::BASE_TYPE_NUMERIC;
+                $basetype = BaseType::NUMERIC;
                 break;
             case "FLOAT":
             case "FLOAT4":
@@ -204,23 +204,23 @@ class Snowflake extends Common
             case "DOUBLE":
             case "DOUBLE PRECISION":
             case "REAL":
-                $basetype = Common::BASE_TYPE_FLOAT;
+                $basetype = BaseType::FLOAT;
                 break;
             case "BOOLEAN":
-                $basetype = Common::BASE_TYPE_BOOLEAN;
+                $basetype = BaseType::BOOLEAN;
                 break;
             case "DATE":
-                $basetype = Common::BASE_TYPE_DATE;
+                $basetype = BaseType::DATE;
                 break;
             case "DATETIME":
             case "TIMESTAMP":
             case "TIMESTAMP_NTZ":
             case "TIMESTAMP_LTZ":
             case "TIMESTAMP_TZ":
-                $basetype = Common::BASE_TYPE_TIMESTAMP;
+                $basetype = BaseType::TIMESTAMP;
                 break;
             default:
-                $basetype = Common::BASE_TYPE_STRING;
+                $basetype = BaseType::STRING;
                 break;
         }
         return $basetype;


### PR DESCRIPTION
Fixes #19  

Tests are intentionally kept using strings to ensure that any BC breaks would be highlighted if someone decides to change the constant's value. 