### PR TITLE
Add object and array to snowflake types

### DIFF
--- a/src/Definition/Snowflake.php
+++ b/src/Definition/Snowflake.php
@@ -22,6 +22,8 @@ class Snowflake extends Common
         "TIME",
         "TIMESTAMP", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP_TZ",
         "VARIANT",
+        "OBJECT",
+        "ARRAY",
         "BINARY","VARBINARY",
     ];
 

--- a/tests/SnowflakeDatatypeTest.php
+++ b/tests/SnowflakeDatatypeTest.php
@@ -205,9 +205,11 @@ class SnowflakeDatatypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testVariant()
+    public function testObjectTypes()
     {
         new Snowflake("VARIANT");
+        new Snowflake("OBJECT");
+        new Snowflake("ARRAY");
     }
 
     public function invalidNumericLengths()


### PR DESCRIPTION
Object and Array are valid snowflake types so should be supported in this lib imho.