### PR TITLE
Redshift - get length from array

### DIFF
--- a/src/Definition/Redshift.php
+++ b/src/Definition/Redshift.php
@@ -32,7 +32,8 @@ class Redshift extends Common
     public function __construct($type, $options = [])
     {
         $this->validateType($type);
-        $this->validateLength($type, isset($options["length"]) ? $options["length"] : null);
+        $options['length'] = $this->processLength($options);
+        $this->validateLength($type, $options['length']);
 
         if (isset($options['compression'])) {
             $this->validateCompression($type, $options['compression']);
@@ -82,6 +83,48 @@ class Redshift extends Common
             "nullable" => $this->isNullable(),
             "compression" => $this->getCompression()
         ];
+    }
+
+    /**
+     * @param array $options
+     * @return string|null
+     * @throws InvalidOptionException
+     */
+    private function processLength($options)
+    {
+        if (!isset($options['length'])) {
+            return null;
+        }
+        if (is_array($options['length'])) {
+            return $this->getLengthFromArray($options['length']);
+        }
+        return $options['length'];
+    }
+
+    /**
+     * @param array $lengthOptions
+     * @throws InvalidOptionException
+     * @return null|string
+     */
+    private function getLengthFromArray($lengthOptions)
+    {
+        $expectedOptions = ['character_maximum', 'numeric_precision', 'numeric_scale'];
+        $diff = array_diff(array_keys($lengthOptions), $expectedOptions);
+        if (count($diff) > 0) {
+            throw new InvalidOptionException(sprintf('Length option "%s" not supported', $diff[0]));
+        }
+
+        $characterMaximum = isset($lengthOptions['character_maximum']) ? $lengthOptions['character_maximum'] : null;
+        $numericPrecision = isset($lengthOptions['numeric_precision']) ? $lengthOptions['numeric_precision'] : null;
+        $numericScale = isset($lengthOptions['numeric_scale']) ? $lengthOptions['numeric_scale'] : null;
+
+        if (!is_null($characterMaximum)) {
+            return $characterMaximum;
+        }
+        if (!is_null($numericPrecision) && !is_null($numericScale)) {
+            return $numericPrecision . ',' . $numericScale;
+        }
+        return $numericPrecision;
     }
 
     /**

--- a/tests/RedshiftDatatypeTest.php
+++ b/tests/RedshiftDatatypeTest.php
@@ -33,6 +33,28 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         new Redshift("NUMERIC", ["length" => "37,0"]);
         new Redshift("NUMERIC", ["length" => "37,37"]);
         new Redshift("NUMERIC", ["length" => "37"]);
+        new Redshift('NUMERIC', [
+            'length' => [
+                'numeric_precision' => '37',
+                'numeric_scale' => '0'
+            ]
+        ]);
+        new Redshift('NUMERIC', [
+            'length' => [
+                'numeric_precision' => '37',
+                'numeric_scale' => '37'
+            ]
+        ]);
+        new Redshift('NUMERIC', [
+            'length' => [
+                'numeric_precision' => '37'
+            ]
+        ]);
+        new Redshift('NUMERIC', [
+            'length' => [
+                'numeric_scale' => '37'
+            ]
+        ]);
     }
 
     /**
@@ -56,6 +78,8 @@ class RedshiftDatatypeTest extends \PHPUnit_Framework_TestCase
         new Redshift("VARCHAR", ["length" => ""]);
         new Redshift("VARCHAR", ["length" => "1"]);
         new Redshift("VARCHAR", ["length" => "65535"]);
+        new Redshift("VARCHAR", ["length" => ['character_maximum' => 65535]]);
+        new Redshift("VARCHAR", ["length" => []]);
     }
 
     /**


### PR DESCRIPTION
Možnost získat `length` z pole

```
'length' => [
     'character_maximum' => 'xxx',
     'numeric_precision' => 'xxx',
     'numeric_scale' => 'xxx',
]
```