### PR TITLE
expose getDefaultLength method for Synapse

### DIFF
--- a/src/Definition/Synapse.php
+++ b/src/Definition/Synapse.php
@@ -133,7 +133,7 @@ class Synapse extends Common
      *
      * @return int|string|null
      */
-    private function getDefaultLength()
+    public function getDefaultLength()
     {
         switch (strtoupper($this->getType())) {
             case self::TYPE_FLOAT:

--- a/tests/SynapseDatatypeTest.php
+++ b/tests/SynapseDatatypeTest.php
@@ -400,4 +400,59 @@ class SynapseDatatypeTest extends TestCase
             ['datetime', null],
         ];
     }
+
+    public function typesForLengthsTest(): \Generator
+    {
+        yield 'TYPE_FLOAT' => [
+            Synapse::TYPE_FLOAT,
+            53
+        ];
+        yield 'TYPE_DECIMAL' => [
+            Synapse::TYPE_DECIMAL,
+            '38,0'
+        ];
+        yield 'TYPE_NUMERIC' => [
+            Synapse::TYPE_NUMERIC,
+            '38,0'
+        ];
+        yield 'TYPE_NCHAR' => [
+            Synapse::TYPE_NCHAR,
+            4000
+        ];
+        yield 'TYPE_NVARCHAR' => [
+            Synapse::TYPE_NVARCHAR,
+            4000
+        ];
+        yield 'TYPE_BINARY' => [
+            Synapse::TYPE_BINARY,
+            8000
+        ];
+        yield 'TYPE_CHAR' => [
+            Synapse::TYPE_CHAR,
+            8000
+        ];
+        yield 'TYPE_VARBINARY' => [
+            Synapse::TYPE_VARBINARY,
+            8000
+        ];
+        yield 'TYPE_VARCHAR' => [
+            Synapse::TYPE_VARCHAR,
+            8000
+        ];
+        yield 'TYPE_REAL' => [
+            Synapse::TYPE_REAL,
+            null
+        ];
+    }
+
+    /**
+     * @dataProvider typesForLengthsTest
+     * @param string $type
+     * @param string|int|null $expectedLength
+     */
+    public function testDefaultLengths(string $type, $expectedLength): void
+    {
+        $def = new Synapse($type, []);
+        $this->assertSame($expectedLength, $def->getDefaultLength());
+    }
 }


### PR DESCRIPTION
Když chcu porovnat sloupce dvou tabulek, tak v connection sa sestavuje jedna definice z metadat a druhá je vytažená z db.
Když sa nezadá explicitně length v connection tak dojde k tomu, že je length null, přitom sqlDefinition bude mět default, ale sql definition nejde porovnávat, protože tam je ještě default a nullable.